### PR TITLE
Removed mistake on CTRL-C command

### DIFF
--- a/module-2/README.md
+++ b/module-2/README.md
@@ -110,7 +110,7 @@ This will open another panel in the IDE where the web browser will be available.
 
 If successful you will see a response from the service that returns the JSON document stored at `/aws-modern-application-workshop/module-2/app/service/mysfits-response.json`
 
-When done testing the service you can stop it by pressing CTRL-c on PC or ⌘-c on Mac.
+When done testing the service you can stop it by pressing CTRL-c on PC or Mac.
 
 #### Pushing the Docker Image to Amazon ECR
 


### PR DESCRIPTION
The instructions said that command-C on the mac was the command to terminate a linux process in the console, but it should just be CTRL-C just like on a PC.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
