### PR TITLE
adding "Service" to Replace me tag for executionRoleArn

### DIFF
--- a/module-2/aws-cli/task-definition.json
+++ b/module-2/aws-cli/task-definition.json
@@ -6,7 +6,7 @@
   "requiresCompatibilities": [
     "FARGATE"
   ],
-  "executionRoleArn": "REPLACE_ME_ECS_ROLE_ARN",
+  "executionRoleArn": "REPLACE_ME_ECS_SERVICE_ROLE_ARN",
   "taskRoleArn": "REPLACE_ME_ECS_TASK_ROLE_ARN",
   "containerDefinitions": [
     {


### PR DESCRIPTION
*Issue #, if available:* #12

*Description of changes:*
I added the word Service to help direct developers to use the ARN from the output: EcsServiceRole


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
