### PR TITLE
Clarifying instructions for which url path to add to index.html

### DIFF
--- a/module-3/README.md
+++ b/module-3/README.md
@@ -93,7 +93,7 @@ Now, in just 5-10 minutes you'll see your code changes make it through your full
 
 #### Update The Website Content in S3
 
-Finally, we need to publish a new index.html page to our S3 bucket so that the new API functionality using query strings to filter responses will be used.  The new index.html file is located at `~/environment/aws-modern-application-workshop/module-3/web/index.html`.  Open this file in your Cloud9 IDE and replace the string indicating “REPLACE_ME” just as you did in Module 1, with the appropriate NLB endpoint.  Refer to the file you already edited in the /module-1/ directory if you need to.  After replacing the endpoint to point at your NLB, upload the new index.html file by running the following command (replacing with the name of the bucket you created in Module 1:
+Finally, we need to publish a new index.html page to our S3 bucket so that the new API functionality using query strings to filter responses will be used.  The new index.html file is located at `~/environment/aws-modern-application-workshop/module-3/web/index.html`.  Open this file in your Cloud9 IDE and replace the string indicating “REPLACE_ME” just as you did in Module 2, with the appropriate NLB endpoint. Remember do not inlcude the /mysfits path. Refer to the file you already edited in the /module-2/ directory if you need to.  After replacing the endpoint to point at your NLB, upload the new index.html file by running the following command (replacing with the name of the bucket you created in Module 1:
 
 ```
 aws s3 cp --recursive ~/environment/aws-modern-application-workshop/module-3/web/ s3://your_bucket_name_here/


### PR DESCRIPTION
*Issue #, if available:* #18 

*Description of changes:*
In both module 2 and 3, I had included /mysfits in the path for mysfitsApiEndpoint. I clarified the instructions to reference in module 3 instructions for updating the index.hml to remind developers not to include /mysfits and to refer to the instructions in module 2 since there are no instructions in module 1 to update the endpoint. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
