### PR TITLE
Using the exact Key from the NLB output

### DIFF
--- a/module-4/README.md
+++ b/module-4/README.md
@@ -37,7 +37,7 @@ aws cognito-idp create-user-pool-client --user-pool-id REPLACE_ME --client-name 
 #### Create an API Gateway VPC Link
 Next, let's turn our attention to creating a new RESTful API in front of our existing Flask service, so that we can perform request authorization before our NLB receives any requests.  We will do this with **Amazon API Gateway**, as described in the module overview.  In order for API Gateway to privately integrate with our NLB, we will configure an **API Gateway VPC Link** that enables API Gateway APIs to directly integrate with backend web services that are privately hosted inside a VPC. **Note:** For the purposes of this workshop, we created the NLB to be *internet-facing* so that it could be called directly in earlier modules. Because of this, even though we will be requiring Authorization tokens in our API after this module, our NLB will still actually be open to the public behind the API Gateway API.  In a real-world scenario, you should create your NLB to be *internal* from the beginning (or create a new internal load balancer to replace the existing one), knowing that API Gateway would be your strategy for Internet-facing API authorization.  But for the sake of time, we'll use the NLB that we've already created that will stay publicly accessible.
 
-Create the VPC Link for our upcoming REST API using the following CLI command (you will need to replace the indicated value with the ARN you saved when the NLB was created in module 2):
+Create the VPC Link for our upcoming REST API using the following CLI command (you will need to replace the indicated value with the Load Balancer ARN you saved when the NLB was created in module 2):
 
 ```
 aws apigateway create-vpc-link --name MysfitsApiVpcLink --target-arns REPLACE_ME_NLB_ARN


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To be clearer for developers, I changed "ARN" to "LoadBalancerArn" which is the exact key that is returned when you create the Load Balancer in module 2


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
