### PR TITLE
update code commit cloneUrl key

### DIFF
--- a/module-5/README.md
+++ b/module-5/README.md
@@ -39,7 +39,7 @@ First, let's create a new CodeCommit repository where the streaming service code
 aws codecommit create-repository --repository-name MythicalMysfitsStreamingService-Repository
 ```
 
-In the response to that command, copy the value for `"cloneValueUrl"`.  It should be of the form:
+In the response to that command, copy the value for `"cloneUrlHttp"`.  It should be of the form:
 `https://git-codecommit.REPLACE_ME_REGION.amazonaws.com/v1/repos/MythicalMysfitsStreamingService-Repository`
 
 Next, let's clone that new and empty repository into our IDE:


### PR DESCRIPTION
My returned key was: cloneUrlHttp not cloneValueUrl, so I changed the label.

*Issue #, if available:*

*Description of changes:*
In module 5 when I create a new code commit repository, I did not get a key/label "cloneValueUrl"

I did have a key: "cloneUrlHttp" that seems to have the correct value, so I changed the label. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
