### PR TITLE
Increase Max Healthy to allow cluster to provision

### DIFF
--- a/workshop-3/README.md
+++ b/workshop-3/README.md
@@ -200,7 +200,7 @@ More information on Task Metadata endpoint can be found here: https://docs.aws.a
 
         1. In Minimum healthy percent enter **50**.
 
-        2. In Maximum healthy percent enter **100**.
+        2. In Maximum healthy percent enter **200**.
 
     The update to the **Like** service will replace the containers that make up the service. ECS offers you control over how the replacement process works. Because the **Like** containers could be serving production traffic, you should not stop all the containers before starting new ones. By specifying a Minimum health percent of 50 and a Maximum healthy percent of 100, ECS will terminate up to 50 percent of the active **Like** containers, then start new containers. Once the new containers are healthy, ECS will terminate the remaining 50 percent of and replace those.
 


### PR DESCRIPTION
100% is too low and will prevent the cluster from provisioning new instances. Increasing this value to 200% allows the cluster to provision a new instance while keeping the existing task in place.\

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
