### PR TITLE
Escape quotes in JSON

### DIFF
--- a/module-2/app/service/mysfits-response.json
+++ b/module-2/app/service/mysfits-response.json
@@ -60,7 +60,7 @@
       "name": "Gary",
       "species": "Kraken",
       "age": 2709,
-      "description": "Gary loves to have a good time. His motto? "I just want to dance." Give Gary a disco ball, a DJ, and a hat that slightly obscures the vision from his top eye, and Gary will dance the year away which, at his age, is like one night in humanoid time. If you're looking for a low-maintenance, high-energy creature companion that never sheds and always shreds, Gary is just the kraken for you.",
+      "description": "Gary loves to have a good time. His motto? \"I just want to dance.\" Give Gary a disco ball, a DJ, and a hat that slightly obscures the vision from his top eye, and Gary will dance the year away which, at his age, is like one night in humanoid time. If you're looking for a low-maintenance, high-energy creature companion that never sheds and always shreds, Gary is just the kraken for you.",
       "goodevil": "Neutral",
       "lawchaos": "Chaotic",
       "thumbImageUri": "https://www.mythicalmysfits.com/images/kraken_thumb.png",


### PR DESCRIPTION
This change is for Module 2, `go` branch.

An issue I had with module 2 was that frontend never showed up mysfits even with CORS fixed. I've found that there is a string in JSON which makes it invalid, added some escape chars.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
