### PR TITLE
Make sure application runs on port 8080

### DIFF
--- a/module-3/app/service/mythicalMysfitsService.go
+++ b/module-3/app/service/mythicalMysfitsService.go
@@ -63,7 +63,7 @@ func showMysfits(w http.ResponseWriter, r *http.Request) {
 
 // Defaults
 var DefaultFormat = "JSON"
-var DefaultPort = ":8088"
+var DefaultPort = ":8080"
 
 func main() {
 	// Check environment

--- a/module-4/app/service/mythicalMysfitsService.go
+++ b/module-4/app/service/mythicalMysfitsService.go
@@ -157,7 +157,7 @@ func mainHandler(w http.ResponseWriter, r *http.Request) {
 
 // Defaults
 var DefaultFormat = "JSON"
-var DefaultPort = ":8088"
+var DefaultPort = ":8080"
 
 func main() {
 	// Check environment


### PR DESCRIPTION
Issue: in module 3 and module 4, go application was not working when deployed.

*Description of changes:*
I'm not sure if it was on purpose or by mistake, but in both module 3 and 4 - the port of Go application was set to `8088` instead of `8080` - which was set in first modules. This change makes sure they're consistent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
