### PR TITLE
Smaller Docker images and better service error reporting

### DIFF
--- a/module-2/app/Dockerfile
+++ b/module-2/app/Dockerfile
@@ -1,6 +1,4 @@
-FROM golang:1.8
-
-EXPOSE 8080
+FROM golang:alpine AS builder
 
 WORKDIR /go/src/app
 COPY ./service/ .
@@ -10,6 +8,12 @@ RUN go get -d -v
 
 RUN echo Building and installing Mystical Mysfits Service
 RUN go install -v
+
+FROM alpine AS app
+COPY --from=builder /go/bin/app /bin/app
+COPY --from=builder /go/src/app/mysfits-response.json /mysfits-response.json
+
+EXPOSE 8080
 
 RUN echo Starting the Go service...
 CMD ["app"]

--- a/module-3/app/Dockerfile
+++ b/module-3/app/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.8
+FROM golang:alpine AS builder
 
-EXPOSE 8080
+RUN apk update && apk add --no-cache git
 
 WORKDIR /go/src/app
 COPY ./service/ .
@@ -10,6 +10,12 @@ RUN go get -d -v
 
 RUN echo Building and installing Mystical Mysfits Service
 RUN go install -v
+
+FROM alpine AS app
+RUN apk update && apk add --no-cache ca-certificates
+COPY --from=builder /go/bin/app /bin/app
+
+EXPOSE 8080
 
 RUN echo Starting the Go service...
 CMD ["app"]

--- a/module-3/app/service/mysfitsTableClient.go
+++ b/module-3/app/service/mysfitsTableClient.go
@@ -204,8 +204,7 @@ func getItems(items []map[string]*dynamodb.AttributeValue) Mysfits {
 
     err := dynamodbattribute.UnmarshalListOfMaps(items, &mysfitList)
     if err != nil {
-        println("Got error unmarshalling items:")
-        println(err.Error())
+        Info.Print("Got error unmarshalling items:", err)
         return nil
     }
 
@@ -218,6 +217,7 @@ func getStringFromItems(items []map[string]*dynamodb.AttributeValue) string {
 
     err := dynamodbattribute.UnmarshalListOfMaps(items, &ms)
     if err != nil {
+        Info.Print("Got error unmarshalling items:", err)
         return ""
     }
 
@@ -243,6 +243,7 @@ func getJSONStringFromItems(items []map[string]*dynamodb.AttributeValue) string 
 
     err := dynamodbattribute.UnmarshalListOfMaps(items, &ms)
     if err != nil {
+        Info.Print("Got error unmarshalling items:", err)
         return ""
     }
 
@@ -276,7 +277,7 @@ func GetAllMysfits() string {
 
     result, err := svc.Scan(input)
     if err != nil {
-        Info.Print("Got error scanning table:")
+        Info.Print("Got error scanning table:", err)
         return ""
     }
 
@@ -320,7 +321,7 @@ func QueryMysfits(filter string, value string) string {
 
     result, err := svc.Scan(input)
     if err != nil {
-        Info.Print("Got error getting item:")
+        Info.Print("Got error scanning item:", err)
         return ""
     }
 

--- a/module-4/app/Dockerfile
+++ b/module-4/app/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.8
+FROM golang:alpine AS builder
 
-EXPOSE 8080
+RUN apk update && apk add --no-cache git
 
 WORKDIR /go/src/app
 COPY ./service/ .
@@ -10,6 +10,12 @@ RUN go get -d -v
 
 RUN echo Building and installing Mystical Mysfits Service
 RUN go install -v
+
+FROM alpine AS app
+RUN apk update && apk add --no-cache ca-certificates
+COPY --from=builder /go/bin/app /bin/app
+
+EXPOSE 8080
 
 RUN echo Starting the Go service...
 CMD ["app"]

--- a/module-4/app/service/mysfitsTableClient.go
+++ b/module-4/app/service/mysfitsTableClient.go
@@ -196,8 +196,7 @@ func getItems(items []map[string]*dynamodb.AttributeValue) Mysfits {
 
     err := dynamodbattribute.UnmarshalListOfMaps(items, &mysfitList)
     if err != nil {
-        println("Got error unmarshalling items:")
-        println(err.Error())
+        Info.Print("Got error unmarshalling items:", err)
         return nil
     }
 
@@ -210,6 +209,7 @@ func getStringFromItem(item map[string]*dynamodb.AttributeValue) string {
 
     err := dynamodbattribute.UnmarshalMap(item, &m)
     if err != nil {
+        Info.Print("Got error unmarshalling item:", err)
         return ""
     }
 
@@ -235,6 +235,7 @@ func getStringFromItems(items []map[string]*dynamodb.AttributeValue) string {
 
     err := dynamodbattribute.UnmarshalListOfMaps(items, &ms)
     if err != nil {
+        Info.Print("Got error unmarshalling items:", err)
         return ""
     }
 
@@ -260,6 +261,7 @@ func getJSONStringFromItems(items []map[string]*dynamodb.AttributeValue) string 
 
     err := dynamodbattribute.UnmarshalListOfMaps(items, &ms)
     if err != nil {
+        Info.Print("Got error unmarshalling items:", err)
         return ""
     }
 
@@ -293,7 +295,7 @@ func GetAllMysfits() string {
 
     result, err := svc.Scan(input)
     if err != nil {
-        Info.Print("Got error scanning table:")
+        Info.Print("Got error scanning table:", err)
         return ""
     }
 
@@ -476,7 +478,7 @@ func QueryMysfits(originalFilter string, originalValue string) string {
 
     result, err := svc.Scan(input)
     if err != nil {
-        Info.Print("Got error getting item:")
+        Info.Print("Got error getting item:", err)
         return ""
     }
 

--- a/module-4/web/register.html
+++ b/module-4/web/register.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <!--
-    A registration page where users who wish you use Mythical Mysfits can
+    A registration page where users who wish to use Mythical Mysfits can
     register with the email address and a password.  The JavaScript below
     uses the Amazon Cognito JavaScript SDK in order to integrate with the service.
   -->

--- a/module-5/app/Dockerfile
+++ b/module-5/app/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.8
+FROM golang:alpine AS builder
 
-EXPOSE 8080
+RUN apk update && apk add --no-cache git
 
 WORKDIR /go/src/app
 COPY ./service/ .
@@ -10,6 +10,12 @@ RUN go get -d -v
 
 RUN echo Building and installing Mystical Mysfits Service
 RUN go install -v
+
+FROM alpine AS app
+RUN apk update && apk add --no-cache ca-certificates
+COPY --from=builder /go/bin/app /bin/app
+
+EXPOSE 8080
 
 RUN echo Starting the Go service...
 CMD ["app"]

--- a/module-5/app/service/mysfitsTableClient.go
+++ b/module-5/app/service/mysfitsTableClient.go
@@ -204,8 +204,7 @@ func getItems(items []map[string]*dynamodb.AttributeValue) Mysfits {
 
     err := dynamodbattribute.UnmarshalListOfMaps(items, &mysfitList)
     if err != nil {
-        println("Got error unmarshalling items:")
-        println(err.Error())
+        Info.Print("Got error unmarshalling items:", err)
         return nil
     }
 
@@ -218,6 +217,7 @@ func getStringFromItem(item map[string]*dynamodb.AttributeValue) string {
 
     err := dynamodbattribute.UnmarshalMap(item, &m)
     if err != nil {
+        Info.Print("Got error unmarshalling item:", err)
         return ""
     }
 
@@ -243,6 +243,7 @@ func getStringFromItems(items []map[string]*dynamodb.AttributeValue) string {
 
     err := dynamodbattribute.UnmarshalListOfMaps(items, &ms)
     if err != nil {
+        Info.Print("Got error unmarshalling items:", err)
         return ""
     }
 
@@ -268,6 +269,7 @@ func getJSONStringFromItems(items []map[string]*dynamodb.AttributeValue) string 
 
     err := dynamodbattribute.UnmarshalListOfMaps(items, &ms)
     if err != nil {
+        Info.Print("Got error unmarshalling items:", err)
         return ""
     }
 
@@ -301,7 +303,7 @@ func GetAllMysfits() string {
 
     result, err := svc.Scan(input)
     if err != nil {
-        Info.Print("Got error scanning table:")
+        Info.Print("Got error scanning table:", err)
         return ""
     }
 
@@ -452,7 +454,7 @@ func QueryMysfits(filter string, value string) string {
 
     result, err := svc.Scan(input)
     if err != nil {
-        Info.Print("Got error getting item:")
+        Info.Print("Got error getting item:", err)
         return ""
     }
 


### PR DESCRIPTION
Use multi-stage builds for much smaller images. Produces ~10MB images instead of ~700MB. May not work with old versions of Docker.

Improved error reporting by ensuring all errors are logged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.