### PR TITLE
added ecr permissions to CodeBuild role in CFN template to fix #95

### DIFF
--- a/module-2/cfn/core.yml
+++ b/module-2/cfn/core.yml
@@ -408,6 +408,8 @@ Resources:
           - Effect: "Allow"
             Action:
             - "ecr:InitiateLayerUpload"
+            - "ecr:UploadLayerPart"
+            - "ecr:CompleteLayerUpload"
             - "ecr:GetAuthorizationToken"
             Resource: "*"
 


### PR DESCRIPTION
*Issue #, if available:*
95

*Description of changes:*
Added "ecr:UploadLayerPart" and "ecr:CompleteLayerUpload" allowed actions to MythicalMysfitsService-CodeBuildServicePolicy in cfn/core.yaml. Looks like without them CodeBuild build fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
