### PR TITLE
perf(dockerfile): update dockerfile to use python2.7-slim as base image

### DIFF
--- a/module-2/app/Dockerfile
+++ b/module-2/app/Dockerfile
@@ -1,13 +1,9 @@
-FROM ubuntu:latest
-RUN echo Updating existing packages, installing and upgrading python and pip.
-RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+FROM python:2.7-slim
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip install --trusted-host pypi.pyhton.org -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
 ENTRYPOINT ["python"]
 CMD ["mythicalMysfitsService.py"]

--- a/module-3/app/Dockerfile
+++ b/module-3/app/Dockerfile
@@ -1,13 +1,9 @@
-FROM ubuntu:latest
-RUN echo Updating existing packages, installing and upgrading python and pip.
-RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+FROM python:2.7-slim
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip install --trusted-host pypi.pyhton.org -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
 ENTRYPOINT ["python"]
 CMD ["mythicalMysfitsService.py"]

--- a/module-4/app/Dockerfile
+++ b/module-4/app/Dockerfile
@@ -1,13 +1,9 @@
-FROM ubuntu:latest
-RUN echo Updating existing packages, installing and upgrading python and pip.
-RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+FROM python:2.7-slim
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip install --trusted-host pypi.pyhton.org -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
 ENTRYPOINT ["python"]
 CMD ["mythicalMysfitsService.py"]

--- a/module-5/app/Dockerfile
+++ b/module-5/app/Dockerfile
@@ -1,13 +1,9 @@
-FROM ubuntu:latest
-RUN echo Updating existing packages, installing and upgrading python and pip.
-RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+FROM python:2.7-slim
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip install --trusted-host pypi.pyhton.org -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
 ENTRYPOINT ["python"]
 CMD ["mythicalMysfitsService.py"]


### PR DESCRIPTION
update dockerfile to use python2.7-slim as the base image instead of ubuntu which speeds up build time from 13 minutes to under 2




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
