### PR TITLE
Removed "vpc" property and changed "ecsStack.ecsService.service" to "…

### DIFF
--- a/module-4/README.md
+++ b/module-4/README.md
@@ -115,8 +115,7 @@ const dynamoDbStack = new DynamoDbStack(app, "MythicalMysfits-DynamoDB", {
     fargateService: ecsStack.ecsService.service
 });
 new APIGatewayStack(app, "MythicalMysfits-APIGateway", {
-  vpc: networkStack.vpc,
-  fargateService: ecsStack.ecsService.service
+    fargateService: ecsStack.ecsService
 });
 ```
 


### PR DESCRIPTION
The `APIGatewayStack` section in the readme file of module 4 produces the following error when built.

```
bin/cdk.ts:29:5 - error TS2345: Argument of type '{ vpc: Vpc; fargateService: NetworkLoadBalancedFargateService; }' is not assignable to parameter of type 'APIGatewayStackProps'. Object literal may only specify known properties, and 'vpc' does not exist in type 'APIGatewayStackProps'.

...

bin/cdk.ts:29:5 - error TS2740: Type 'FargateService' is missing the following properties from type 'NetworkLoadBalancedFargateService': assignPublicIp, service, desiredCount, loadBalancer, and 5 more.
```

This change updates the content of the readme file to match the source file of module 4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.