### PR TITLE
Workaround for AttributeError: 'Request' object has no attribute 'is_xhr'

### DIFF
--- a/module-2/app/service/mythicalMysfitsService.py
+++ b/module-2/app/service/mythicalMysfitsService.py
@@ -4,6 +4,7 @@ from flask_cors import CORS
 # A very basic API created using Flask that has two possible routes for requests.
 
 app = Flask(__name__)
+app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 CORS(app)
 
 # The service basepath has a short response just to ensure that healthchecks


### PR DESCRIPTION
When pretty printing during call of jsonify, flask uses outdated method Request.is_xhr. This workaround disables pretty printing for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
