### PR TITLE
add datatype specification to ajax POST operation.(like/adopt)

### DIFF
--- a/module-4/web/index.html
+++ b/module-4/web/index.html
@@ -473,6 +473,7 @@
           url : mysfitsApi,
           type : 'POST',
           headers : {'Authorization' : idJwt },
+          dataType : 'text',
           success : function(response) {
             console.log("here" + mysfitId);
             callback(mysfitId);
@@ -507,6 +508,7 @@
           async : false,
           type : 'POST',
           headers : {'Authorization' : idJwt },
+          dataType : 'text',
           success : function(response) {
             callback();
           },

--- a/module-5/web/index.html
+++ b/module-5/web/index.html
@@ -482,6 +482,7 @@
           url : mysfitsApi,
           type : 'POST',
           headers : {'Authorization' : idJwt },
+          dataType : 'text',
           success : function(response) {
             console.log("here" + mysfitId);
             callback(mysfitId);
@@ -516,6 +517,7 @@
           async : false,
           type : 'POST',
           headers : {'Authorization' : idJwt },
+          dataType : 'text',
           success : function(response) {
             callback();
           },


### PR DESCRIPTION
*Issue #175 *

*Description of changes:*
The Java backend seems to respond with null body for POST.
As a result, Ajax seems to fail to parse json and output "parseerror".
Specified datatype as "text" so as not to fail to parse JSON.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
