### PR TITLE
update health-check path to /mysfits

### DIFF
--- a/module-2/README.md
+++ b/module-2/README.md
@@ -203,7 +203,7 @@ When this command has successfully completed, a new file will be created in your
 Next, use the CLI to create an NLB **target group**. A target group allows AWS resources to register themselves as targets for requests that the load balancer receives to forward.  Our service containers will automatically register to this target so that they can receive traffic from the NLB when they are provisioned. This command includes one value that will need to be replaced, your `vpc-id` which can be found as a value within the earlier saved `MythicalMysfitsCoreStack` output returned by CloudFormation.
 
 ```
-aws elbv2 create-target-group --name MythicalMysfits-TargetGroup --port 8080 --protocol TCP --target-type ip --vpc-id REPLACE_ME_VPC_ID --health-check-interval-seconds 10 --health-check-path / --health-check-protocol HTTP --healthy-threshold-count 3 --unhealthy-threshold-count 3 > ~/environment/target-group-output.json
+aws elbv2 create-target-group --name MythicalMysfits-TargetGroup --port 8080 --protocol TCP --target-type ip --vpc-id REPLACE_ME_VPC_ID --health-check-interval-seconds 10 --health-check-path /mysfits --health-check-protocol HTTP --healthy-threshold-count 3 --unhealthy-threshold-count 3 > ~/environment/target-group-output.json
 ```
 
 When this command completes, its output will be saved to `target-group-output.json` in your IDE. You will reference the `TargetGroupArn` value in a subsequent step.


### PR DESCRIPTION
Issue #, if available:
current healthcheck path of the NLB is "/" which results in timeout for the NLB

Description of changes:
when creating the NLB, change the health-check path to point to "/mysfits" which is the correct path the app is responding on

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

