### PR TITLE
fix: Pin werkzeug dependency to <1.0. Fixes #167, #161

### DIFF
--- a/module-2/app/service/requirements.txt
+++ b/module-2/app/service/requirements.txt
@@ -1,3 +1,4 @@
 Flask==0.12.2
 flask-cors==3.0.0
 boto3==1.7.16
+werkzeug<1.0

--- a/module-3/app/service/requirements.txt
+++ b/module-3/app/service/requirements.txt
@@ -1,3 +1,4 @@
 Flask==0.12.2
 flask-cors==3.0.0
 boto3==1.7.16
+werkzeug<1.0

--- a/module-4/app/service/requirements.txt
+++ b/module-4/app/service/requirements.txt
@@ -1,3 +1,4 @@
 Flask==0.12.2
 flask-cors==3.0.0
 boto3==1.7.16
+werkzeug<1.0

--- a/module-5/app/service/requirements.txt
+++ b/module-5/app/service/requirements.txt
@@ -1,3 +1,4 @@
 Flask==0.12.2
 flask-cors==3.0.0
 boto3==1.7.16
+werkzeug<1.0


### PR DESCRIPTION
*Issue #, if available:*

#167, #161

*Description of changes:*
Pin werkzeug dependency to <1.0 to fix flask crash on GET /

Also see PR#162. This PR has the changes requested by @cd17822


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
