### PR TITLE
Updated python version from 2.7 to 3*

### DIFF
--- a/module-2/app/Dockerfile
+++ b/module-2/app/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:latest
 RUN echo Updating existing packages, installing and upgrading python and pip.
 RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+RUN apt-get install -y python3-pip python3-dev build-essential
+RUN pip3 install --upgrade pip
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip3 install -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
-ENTRYPOINT ["python"]
+ENTRYPOINT ["python3"]
 CMD ["mythicalMysfitsService.py"]


### PR DESCRIPTION
 Python 2.7 is not shipped anymore with Ubuntu 20.04, nearly all python related packages are now called python3-*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
