### PR TITLE
print support for python3 - mysfitsTableClient.py module3 file

### DIFF
--- a/module-3/app/service/mysfitsTableClient.py
+++ b/module-3/app/service/mysfitsTableClient.py
@@ -101,13 +101,13 @@ if __name__ == "__main__":
     value = args.value
 
     if args.filter and args.value:
-        print 'filter is '+args.filter
-        print 'value is '+args.value
+        print('filter is '+args.filter)
+        print('value is '+args.value)
 
-        print "Getting filtered values"
+        print("Getting filtered values")
         items = queryMysfitItems(args.filter, args.value)
     else:
-        print "Getting all values"
+        print("Getting all values")
         items = getAllMysfits()
 
-    print items
+    print(items)


### PR DESCRIPTION
**Issue #200**
Reported in the issue [mysfitsTableClient.py error at deployment post build](https://github.com/aws-samples/aws-modern-application-workshop/issues/200) but hasn't been fixed.

**Description of changes:**
Based on the findings reported in the issue linked above, this commits comprises just a small change to the print statements in the python/module3/mysfitsTableClient.py file.  Since python2 is deprecated and the latest code was causing the normal app deployment to fail, it was seen as important to quickly fix it in order for future users to have a good experience.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
