### PR TITLE
Add print parenthesis

### DIFF
--- a/module-3/app/service/mysfitsTableClient.py
+++ b/module-3/app/service/mysfitsTableClient.py
@@ -101,13 +101,13 @@ if __name__ == "__main__":
     value = args.value
 
     if args.filter and args.value:
-        print 'filter is '+args.filter
-        print 'value is '+args.value
+        print ('filter is '+args.filter)
+        print ('value is '+args.value)
 
-        print "Getting filtered values"
+        print ("Getting filtered values")
         items = queryMysfitItems(args.filter, args.value)
     else:
-        print "Getting all values"
+        print ("Getting all values")
         items = getAllMysfits()
 
-    print items
+    print (items)


### PR DESCRIPTION
The lack of parenthesis in the print function caused my container to crash constantly since this code crashes. I am adding necessary parenthesis in the print function to prevent it from crashing.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
