### PR TITLE
Update Python to Python3 for compatibility reason with Cloud9 in the …

### DIFF
--- a/module-2/app/Dockerfile
+++ b/module-2/app/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:latest
 RUN echo Updating existing packages, installing and upgrading python and pip.
 RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+RUN apt-get install -y python3-pip python3-dev build-essential
+RUN pip3 install --upgrade pip
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip3 install -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
-ENTRYPOINT ["python"]
+ENTRYPOINT ["python3"]
 CMD ["mythicalMysfitsService.py"]

--- a/module-3/app/Dockerfile
+++ b/module-3/app/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:latest
 RUN echo Updating existing packages, installing and upgrading python and pip.
 RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+RUN apt-get install -y python3-pip python3-dev build-essential
+RUN pip3 install --upgrade pip
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip3 install -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
-ENTRYPOINT ["python"]
+ENTRYPOINT ["python3"]
 CMD ["mythicalMysfitsService.py"]

--- a/module-4/app/Dockerfile
+++ b/module-4/app/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:latest
 RUN echo Updating existing packages, installing and upgrading python and pip.
 RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+RUN apt-get install -y python3-pip python3-dev build-essential
+RUN pip3 install --upgrade pip
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip3 install -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
-ENTRYPOINT ["python"]
+ENTRYPOINT ["python3"]
 CMD ["mythicalMysfitsService.py"]

--- a/module-5/app/Dockerfile
+++ b/module-5/app/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:latest
 RUN echo Updating existing packages, installing and upgrading python and pip.
 RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+RUN apt-get install -y python3-pip python3-dev build-essential
+RUN pip3 install --upgrade pip
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip3 install -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
-ENTRYPOINT ["python"]
+ENTRYPOINT ["python3"]
 CMD ["mythicalMysfitsService.py"]


### PR DESCRIPTION
Dockerfile modification from python2 to python3

*Issue #, if available:*
Python Version compatibility with Cloud9. Cloud9 by default is now using Python 3.6.10 while the Dockerfile in Module 2 is using Python2

*Description of changes:*
Updated the Dockerfile with the necessary changes to support and build the image with Python3. Flask app is will work correctly once packaged with this dockerfile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
