### PR TITLE
Use Python3

### DIFF
--- a/module-2/app/Dockerfile
+++ b/module-2/app/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest
 RUN echo Updating existing packages, installing and upgrading python and pip.
 RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+RUN apt-get install -y python3-pip python-dev build-essential
+RUN pip3 install --upgrade pip
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService

--- a/module-2/app/Dockerfile
+++ b/module-2/app/Dockerfile
@@ -9,5 +9,5 @@ WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
 RUN pip install -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
-ENTRYPOINT ["python"]
+ENTRYPOINT ["python3"]
 CMD ["mythicalMysfitsService.py"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
python-pip is no longer available in ubuntu:latest, so we install python3-pip instead
we then call pip3 binary to upgrade
we then change the entry-point to python3 as pip will only install packages to python3 site libraries

I have verified these changes successfully build and are able to run this application

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
