### PR TITLE
Python3 Support

### DIFF
--- a/module-2/app/Dockerfile
+++ b/module-2/app/Dockerfile
@@ -9,5 +9,5 @@ WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
 RUN pip3 install -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
-ENTRYPOINT ["python"]
+ENTRYPOINT ["python3"]
 CMD ["mythicalMysfitsService.py"]

--- a/module-2/app/Dockerfile
+++ b/module-2/app/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:latest
 RUN echo Updating existing packages, installing and upgrading python and pip.
 RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+RUN apt-get install -y python3-pip python-dev build-essential
+RUN pip3 install --upgrade pip
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip3 install -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
 ENTRYPOINT ["python"]
 CMD ["mythicalMysfitsService.py"]

--- a/module-3/app/service/mysfitsTableClient.py
+++ b/module-3/app/service/mysfitsTableClient.py
@@ -101,13 +101,13 @@ if __name__ == "__main__":
     value = args.value
 
     if args.filter and args.value:
-        print 'filter is '+args.filter
-        print 'value is '+args.value
+        print('filter is '+args.filter)
+        print('value is '+args.value)
 
-        print "Getting filtered values"
+        print("Getting filtered values")
         items = queryMysfitItems(args.filter, args.value)
     else:
-        print "Getting all values"
+        print("Getting all values")
         items = getAllMysfits()
 
-    print items
+    print(items)


### PR DESCRIPTION
*Issue #, if available:*
In Ubuntu 20.04 there is no python-pip package anymore, only python3-pip. 
Also the command is called pip3 not only pip

also in some file the old print statement was used

*Description of changes:*
** changed `pyhon-pip` to `python3-pip`
** changed `pip` to `pip3`
** changed `python` to `python3`
** changed print statement to print() function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
