### PR TITLE
Fix curl typo java module 1

### DIFF
--- a/module-1/README.md
+++ b/module-1/README.md
@@ -176,7 +176,7 @@ http://REPLACE_ME_BUCKET_NAME.s3-website.REPLACE_ME_YOUR_REGION.amazonaws.com
 Verify that the static website is being served correctly:
 
 ```
-curl -I http://REPLACE_ME_BUCKET_NAME.s3-website-REPLACE_ME_YOUR_REGION.amazonaws.com"
+curl -I "http://REPLACE_ME_BUCKET_NAME.s3-website.REPLACE_ME_YOUR_REGION.amazonaws.com"
 HTTP/1.1 200 OK
 ```
 

--- a/module-1/README.md
+++ b/module-1/README.md
@@ -165,7 +165,7 @@ Now you can use the website endpoint to serve static content directly from your 
 
 For us-east-1 (N. Virginia), us-west-2 (Oregon), eu-west-1 (Ireland) use:
 ```
-http://REPLACE_ME_BUCKET_NAME.s3-website-REPLACE_ME_YOUR_REGION.amazonaws.com
+http://REPLACE_ME_BUCKET_NAME.s3-website.REPLACE_ME_YOUR_REGION.amazonaws.com
 ```
 
 For us-east-2 (Ohio) use:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There are some typos at the end of the java module-1 section in the urls for testing the access to the static website.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
