### PR TITLE
Update README.md

### DIFF
--- a/module-1/README.md
+++ b/module-1/README.md
@@ -52,11 +52,6 @@ In the terminal, change directory to the newly cloned repository directory:
 cd aws-modern-application-workshop
 ```
 
-In order to build the solution you will need to install all depedencies listed in package.json. Type:
-```
-npm install
-```
-
 ### Creating a Static Website in Amazon S3
 
 #### Overview of the `frontend`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removed the step to invoke `npm install` in the repo's root folder, as there is no package.json file in that folder and `npm` will do nothing (but create an empty package.json). This did confuse me.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
