### PR TITLE
Update to pull .NET container images from MCR instead of Docker Hub

### DIFF
--- a/module-2/webapi/Dockerfile
+++ b/module-2/webapi/Dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk as build
+FROM mcr.microsoft.com/dotnet/sdk:2.1 as build
 WORKDIR /app
 COPY . /app
 RUN dotnet publish -c Release -r linux-musl-x64 -o out
 
-FROM microsoft/dotnet:2.1-runtime-deps-alpine
+FROM mcr.microsoft.com/dotnet/runtime:2.1-alpine
 WORKDIR /app
 COPY --from=build /app/out ./
 ENV ASPNETCORE_ENVIRONMENT=Production

--- a/module-3/webapi/Dockerfile
+++ b/module-3/webapi/Dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk as build
+FROM mcr.microsoft.com/dotnet/sdk:2.1 as build
 WORKDIR /app
 COPY . /app
 RUN dotnet publish -c Release -r linux-musl-x64 -o out
 
-FROM microsoft/dotnet:2.1-runtime-deps-alpine
+FROM mcr.microsoft.com/dotnet/runtime:2.1-alpine
 WORKDIR /app
 COPY --from=build /app/out ./
 ENV ASPNETCORE_ENVIRONMENT=Production

--- a/module-4/webapi/Dockerfile
+++ b/module-4/webapi/Dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk as build
+FROM mcr.microsoft.com/dotnet/sdk:2.1 as build
 WORKDIR /app
 COPY . /app
 RUN dotnet publish -c Release -r linux-musl-x64 -o out
 
-FROM microsoft/dotnet:2.1-runtime-deps-alpine
+FROM mcr.microsoft.com/dotnet/runtime:2.1-alpine
 WORKDIR /app
 COPY --from=build /app/out ./
 ENV ASPNETCORE_ENVIRONMENT=Production

--- a/module-5/webapi/Dockerfile
+++ b/module-5/webapi/Dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk as build
+FROM mcr.microsoft.com/dotnet/sdk:2.1 as build
 WORKDIR /app
 COPY . /app
 RUN dotnet publish -c Release -r linux-musl-x64 -o out
 
-FROM microsoft/dotnet:2.1-runtime-deps-alpine
+FROM mcr.microsoft.com/dotnet/runtime:2.1-alpine
 WORKDIR /app
 COPY --from=build /app/out ./
 ENV ASPNETCORE_ENVIRONMENT=Production


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
.NET Core 2.1 are now only available from MCR, attempts to pull from Docker Hub will be denied. Updated Dockerfile to use the new repos.

> Starting on August 21st, .NET Core 2.1 Docker container images will no longer be available on Docker Hub, but exclusively on Microsoft Container Registry (MCR).

[.NET Core 2.1 container images will be deleted from Docker Hub](https://devblogs.microsoft.com/dotnet/net-core-2-1-container-images-will-be-deleted-from-docker-hub/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
