### PR TITLE
add mod init in go docker file

### DIFF
--- a/module-2/app/Dockerfile
+++ b/module-2/app/Dockerfile
@@ -3,6 +3,9 @@ FROM golang:alpine AS builder
 WORKDIR /go/src/app
 COPY ./service/ .
 
+RUN echo creating mod file
+RUN go mod init 
+
 RUN echo Fetching project dependencies
 RUN go get -d -v
 

--- a/module-3/app/Dockerfile
+++ b/module-3/app/Dockerfile
@@ -5,6 +5,9 @@ RUN apk update && apk add --no-cache git
 WORKDIR /go/src/app
 COPY ./service/ .
 
+RUN echo creating mod file
+RUN go mod init 
+
 RUN echo Fetching project dependencies
 RUN go get -d -v
 

--- a/module-4/app/Dockerfile
+++ b/module-4/app/Dockerfile
@@ -5,6 +5,9 @@ RUN apk update && apk add --no-cache git
 WORKDIR /go/src/app
 COPY ./service/ .
 
+RUN echo creating mod file
+RUN go mod init 
+
 RUN echo Fetching project dependencies
 RUN go get -d -v
 

--- a/module-5/app/Dockerfile
+++ b/module-5/app/Dockerfile
@@ -5,6 +5,9 @@ RUN apk update && apk add --no-cache git
 WORKDIR /go/src/app
 COPY ./service/ .
 
+RUN echo creating mod file
+RUN go mod init 
+
 RUN echo Fetching project dependencies
 RUN go get -d -v
 


### PR DESCRIPTION

In go docker file  "go mod init" should be added else it will throw below error while building docker container 
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
The command '/bin/sh -c go get -d -v' returned a non-zero code: 1


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
