### PR TITLE
Updated requirements.txt for python module 2

### DIFF
--- a/module-2/app/service/requirements.txt
+++ b/module-2/app/service/requirements.txt
@@ -1,4 +1,5 @@
 boto3==1.11.16
-Flask==1.1.1
+Flask==1.1.4
 Flask-Cors==3.0.8
 werkzeug<1.0
+markupsafe==2.0.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

requirements.txt was outdated leading to multiple errors when trying to run docker image. 

The fix was to change version of flask to 1.1.4 and also to add markupsafe too.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
