### PR TITLE
Python Updates due to Recent Jinja2 Changes

### DIFF
--- a/module-2/app/service/requirements.txt
+++ b/module-2/app/service/requirements.txt
@@ -1,4 +1,3 @@
 boto3==1.11.16
-Flask==1.1.1
-Flask-Cors==3.0.8
-werkzeug<1.0
+Flask==2.1.0
+Flask-Cors>=3.0.8

--- a/module-3/app/service/requirements.txt
+++ b/module-3/app/service/requirements.txt
@@ -1,4 +1,3 @@
 boto3==1.11.16
-Flask==1.1.1
-Flask-Cors==3.0.8
-werkzeug<1.0
+Flask==2.1.0
+Flask-Cors>3.0.8

--- a/module-4/app/service/requirements.txt
+++ b/module-4/app/service/requirements.txt
@@ -1,4 +1,3 @@
 boto3==1.11.16
-Flask==1.1.1
-Flask-Cors==3.0.8
-werkzeug<1.0
+Flask==2.1.0
+Flask-Cors>3.0.8

--- a/module-5/app/service/requirements.txt
+++ b/module-5/app/service/requirements.txt
@@ -1,4 +1,3 @@
 boto3==1.11.16
-Flask==1.1.1
-Flask-Cors==3.0.8
-werkzeug<1.0
+Flask==2.1.0
+Flask-Cors>3.0.8


### PR DESCRIPTION
*Issue #, if available:*
The recent change to Jinja2 removing escape from the exposed functions means it is not available for flask to export.

*Description of changes:*
Moving to a new version of flask in the requirement file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
