### PR TITLE
Update Dockerfile to make use of openjdk 8

### DIFF
--- a/module-2/app/Dockerfile
+++ b/module-2/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 VOLUME /tmp
 ADD service/target/mythical-mysfits-1.0-SNAPSHOT.jar app.jar
 EXPOSE 8080


### PR DESCRIPTION
As per instructions, the java installation conforms to openjdk 8

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
